### PR TITLE
Fix comparison of integer expressions of different signedness warning

### DIFF
--- a/absl/hash/internal/hash.h
+++ b/absl/hash/internal/hash.h
@@ -798,7 +798,7 @@ AbslHashValue(H hash_state, const absl::variant<T...>& v) {
 template <typename H, size_t N>
 H AbslHashValue(H hash_state, const std::bitset<N>& set) {
   typename H::AbslInternalPiecewiseCombiner combiner;
-  for (int i = 0; i < N; i++) {
+  for (size_t i = 0; i < N; i++) {
     unsigned char c = static_cast<unsigned char>(set[i]);
     hash_state = combiner.add_buffer(std::move(hash_state), &c, sizeof(c));
   }


### PR DESCRIPTION
```
src/third_party/abseil-cpp/dist/absl/hash/internal/hash.h:633:21: error: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Werror=sign-compare]
```

This warning happens only on Big Endian build variants such as s390x.